### PR TITLE
list extensions functionality

### DIFF
--- a/analytics_builder
+++ b/analytics_builder
@@ -8,7 +8,7 @@ import argparse, tempfile, traceback
 
 sys.path.append(os.fspath(pathlib.Path(__file__).parent.joinpath('scripts')))
 
-import blockMetadataGenerator, buildExtension, configure_designer, jsonHelper, uploadExtension
+import blockMetadataGenerator, buildExtension, configure_designer, jsonHelper, uploadExtension, listExtensions
 
 class Command(object):
 	def __init__(self, name, help, sub_commands=None, required=True):
@@ -57,6 +57,11 @@ def main():
 					   'Upload a zip file of the Analytics Builder extension and optionally upload it to the Cumulocity inventory. ' +
 					   'You can also delete already uploaded extensions. After uploading or deleting an extension, ' +
 					   'you have to restart the Apama service for this to take effect.')
+		])
+		,
+		Command('list', 'list all extensions', [
+			SubCommand('extensions', 'list extensions', listExtensions.add_arguments, listExtensions.run, False,
+					   'Lists all extensions installed on the given tenant. ')
 		])
 	]
 

--- a/scripts/listExtensions.py
+++ b/scripts/listExtensions.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# $Copyright (c) 2019 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.$
+# Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG
+import os, urllib, buildExtension
+
+def add_arguments(parser):
+    """ Add parser arguments. """
+    #these are optional arguments, requires at least one of them to perform upload or delete
+    remote = parser.add_argument_group(
+        'upload or delete (requires at least the following arguments: --cumulocity_url, --username, --password, (--input or --name))')
+    remote.add_argument('--cumulocity_url', metavar='URL', help='the base Cumulocity URL')
+    remote.add_argument('--username',
+                        help='the Cumulocity tenant identifier and the username in the <tenantId>/<username> format')
+    remote.add_argument('--password', help='the Cumulocity password')
+
+def run(args):
+    # Support remote operations and whether they are mandatory.
+    remote = {'cumulocity_url': True, 'username': True, 'password': True}
+
+    # checks if all manadatory remote options are provided
+    buildExtension.isAllRemoteOptions(args,remote)
+    connection = buildExtension.C8yConnection( args.cumulocity_url, args.username,args.password)
+    try:
+        extension_mos = connection.do_get('/inventory/managedObjects', {'fragmentType': "pas_extension", "pageSize": 2000})
+        for mo in extension_mos['managedObjects']: 
+            print(mo['pas_extension'])
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+	        raise Exception(
+		        f'Failed to perform REST request for resource /inventory/managedObjects on url {connection.base_url}. Verify that the base Cumulocity URL is correct.')
+        raise err
+


### PR DESCRIPTION
This adds functionality to list all extensions installed on a tenant. While you can also get this from the File Repository in Cumulocity, having it in the script is more convenient especially if lots of non-extension files exist in the tenant.

- Implementation uses the standard mechanisms of the SDK to provide an additional command "list extensions" (note the plural)
- ignoreVersion is not implemented as the list functionality should not be version specific
- As no paging is implemented, this will work for up to 2000 extensions installed on a tenant. 
- Output is just the list of extensions with each extension on a new line to allow for easy inclusion in other scripts